### PR TITLE
Add ci to push doc to wiki

### DIFF
--- a/.github/workflows/push-doc-to-wiki.yml
+++ b/.github/workflows/push-doc-to-wiki.yml
@@ -1,0 +1,38 @@
+name: Push Docs to Wiki
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy-wiki:
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Set up Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Clone wiki
+        env:
+          WIKI_TOKEN: ${{ secrets.WIKI_TOKEN }}
+        run: |
+          git clone https://x-access-token:$WIKI_TOKEN@github.com/${{ github.repository }}.wiki.git wiki
+
+      - name: Copy docs to wiki
+        run: |
+          rm -rf wiki/*
+          cp -r docs/* wiki/
+
+      - name: Push to wiki
+        working-directory: wiki
+        run: |
+          git add .
+          git commit -m "Update wiki from $GITHUB_SHA" || echo "No changes to commit"
+          git push origin master

--- a/docs/Home.MD
+++ b/docs/Home.MD
@@ -1,0 +1,1 @@
+# DDOLIB wiki


### PR DESCRIPTION
CI CD is now setup to push the content of docs/ directory to the wiki.

The job will trigger only on main. Content for the wiki is written in Markdown.