### PR TITLE
Fix stocking cost calculation in PSFastLowerBound

### DIFF
--- a/src/main/java/org/ddolib/examples/pigmentscheduling/PSFastLowerBound.java
+++ b/src/main/java/org/ddolib/examples/pigmentscheduling/PSFastLowerBound.java
@@ -119,7 +119,7 @@ public class PSFastLowerBound implements FastLowerBound<PSState> {
             }
             if (!itemDemands.isEmpty()) {
                 ItemDemand item = itemDemands.poll();
-                stockingCostLb += item.cost() * (time - item.deadLine());
+                stockingCostLb += item.cost() * (item.deadLine() - time);
             }
         }
         return changeOverLb + stockingCostLb;


### PR DESCRIPTION
The stocking cost calculation was previously using `(time as isize - deadline)`, which results in negative stocking costs when items are produced before their deadline. This seems to be incorrect, as stocking costs should be positive when items are held in inventory before their required deadline.